### PR TITLE
relevant vendor removal changes to docker and readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Alternatively, AKS Periscope can be deployed directly with `kubectl`. See instru
 To locally build this project from the root of this repository:
 
 ```
-CGO_ENABLED=0 GOOS=linux go build -mod=vendor github.com/Azure/aks-periscope/cmd/aks-periscope
+CGO_ENABLED=0 GOOS=linux go build -mod=mod github.com/Azure/aks-periscope/cmd/aks-periscope
 ```
 
 **Tip**: In order to test local changes, user can build the local image via `Dockerfile` and then push it to your local hub. This way, user should be able to reference this test image in the `deployment\aks-periscope.yaml` `containers` property `image` attribute reference to your published test docker image. 

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -2,7 +2,7 @@ FROM golang AS builder
 RUN mkdir /app
 ADD . /app
 WORKDIR /app
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor github.com/Azure/aks-periscope/cmd/aks-periscope
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=mod github.com/Azure/aks-periscope/cmd/aks-periscope
 
 FROM alpine
 RUN apk --no-cache add ca-certificates


### PR DESCRIPTION
Since `vendor` will be removed, we could make these changes in docker and for CI.

What do you think? @arnaud-tincelin  (This is direct PR to your fork in case you think its a good idea) https://github.com/Azure/aks-periscope/pull/46 

Thank you.